### PR TITLE
NO JIRA. Corrections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Steps:
     #!bash
     git clone https://github.com/DANS-KNAW/easy-transform-metadata.git
     cd easy-transform-metadata 
-    mvn install
+    mvn clean install
 
 If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM 
 packaging will be activated. If `rpm` is available, but at a different path, then activate it by using

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Prerequisites:
 
 Steps:
     
-    #!bash
     git clone https://github.com/DANS-KNAW/easy-transform-metadata.git
     cd easy-transform-metadata 
     mvn install

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ ARGUMENTS
 EXAMPLES
 --------
 
-    easy-transform-metadata -d b2149eb8-eb51-11e9-896f-6b3af1277c7b -t my-transformation.xslt
-    easy-transform-metadata -l my-datasetIds.txt -t my-transformation.xslt -o transformation-output/
+    easy-transform-metadata -b b2149eb8-eb51-11e9-896f-6b3af1277c7b -t my-transformation.xslt
+    easy-transform-metadata -l my-bagIds.txt -t my-transformation.xslt -o transformation-output/
 
 
 INSTALLATION AND CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ easy-transform-metadata
 SYNOPSIS
 --------
 
-    easy-transform-metadata [-d,--bagId|-l,--list] [-t,--transform] [-o,--output]
+    easy-transform-metadata [-b,--bagId|-l,--list] [-t,--transform] [-o,--output]
 
 
 DESCRIPTION
@@ -19,13 +19,13 @@ ARGUMENTS
 
     Options:
 
-       -d, --bagId  <arg>       The bag for which to transform the metadata
-       -l, --list  <arg>        A file containing a newline separated list of bag-ids for which to
-                                transform the metadata
-       -o, --output  <arg>      The directory in which to output the resulting metadata. If '-d' is used, this is
+       -b, --bagId  <arg>       The bag for which to transform the metadata
+       -l, --list  <arg>        A file containing a newline separated list of bag-ids for which to transform the
+                                metadata
+       -o, --output  <arg>      The directory in which to output the resulting metadata. If '-b' is used, this is
                                 optional (default to stdout); if '-l' is used, this argument is mandatory.
-       -t, --transform  <arg>   The file containing an XSLT to be applied to the metadata of the given bag(s);
-                                if not provided, no transformation will be performed, but the input for the
+       -t, --transform  <arg>   The file containing an XSLT to be applied to the metadata of the given bags(s); if
+                                not provided, no transformation will be performed, but the input for the
                                 transformation will be returned.
        -h, --help               Show help message
        -v, --version            Show version of this program

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Prerequisites:
 Steps:
     
     #!bash
-    git clone https://github.com/DANS-KNAW/easy-transform-metadata .git
+    git clone https://github.com/DANS-KNAW/easy-transform-metadata.git
     cd easy-transform-metadata 
     mvn install
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ easy-transform-metadata
 SYNOPSIS
 --------
 
-    easy-transform-metadata <[--datasetId|-d]|[--list|-l]> [--transform|-t] [--output|-o]
+    easy-transform-metadata [-d,--bagId|-l,--list] [-t,--transform] [-o,--output]
 
 
 DESCRIPTION
@@ -19,12 +19,12 @@ ARGUMENTS
 
     Options:
 
-       -d, --datasetId  <arg>   The datasetId (UUID) for which to transform the metadata
-       -l, --list  <arg>        A file containing a newline separated list of datasetIds (UUID) for which to
+       -d, --bagId  <arg>       The bag for which to transform the metadata
+       -l, --list  <arg>        A file containing a newline separated list of bag-ids for which to
                                 transform the metadata
-       -o, --output  <arg>      The directory in which to output the resultant metadata. If '-d' is used, this is
+       -o, --output  <arg>      The directory in which to output the resulting metadata. If '-d' is used, this is
                                 optional (default to stdout); if '-l' is used, this argument is mandatory.
-       -t, --transform  <arg>   The file containing an XSLT to be applied to the metadata of the given dataset(s);
+       -t, --transform  <arg>   The file containing an XSLT to be applied to the metadata of the given bag(s);
                                 if not provided, no transformation will be performed, but the input for the
                                 transformation will be returned.
        -h, --help               Show help message
@@ -39,31 +39,25 @@ EXAMPLES
 
 INSTALLATION AND CONFIGURATION
 ------------------------------
-
-
-1. Unzip the tarball to a directory of your choice, typically `/usr/local/`
-2. A new directory called easy-transform-metadata-<version> will be created
-3. Add the command script to your `PATH` environment variable by creating a symbolic link to it from a directory that is
-   on the path, e.g. 
-   
-        ln -s /usr/local/easy-transform-metadata-<version>/bin/easy-transform-metadata /usr/bin
-
-
-
-General configuration settings can be set in `cfg/application.properties` and logging can be configured
-in `cfg/logback.xml`. The available settings are explained in comments in aforementioned files.
-
+Currently this project is build only as an RPM package for RHEL7/CentOS7 and later. The RPM will install the binaries to
+`/opt/dans.knaw.nl/easy-transform-metadata `, the configuration files to `/etc/opt/dans.knaw.nl/easy-transform-metadata `,
+and will install the service script for `systemd`. 
 
 BUILDING FROM SOURCE
 --------------------
-
 Prerequisites:
 
 * Java 8 or higher
 * Maven 3.3.3 or higher
+* RPM
 
 Steps:
+    
+    #!bash
+    git clone https://github.com/DANS-KNAW/easy-transform-metadata .git
+    cd easy-transform-metadata 
+    mvn install
 
-        git clone https://github.com/DANS-KNAW/easy-transform-metadata.git
-        cd easy-transform-metadata
-        mvn install
+If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM 
+packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
+Maven's `-P` switch: `mvn -Pprm install`.

--- a/src/main/scala/nl/knaw/dans/easy/transform/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/CommandLineOptions.scala
@@ -29,7 +29,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = "Tool to transform EASY metadata (dataset.xml en files.xml) into other formats"
   val synopsis: String =
     s"""
-       |  $printedName <[--datasetId|-d]|[--list|-l]> [--transform|-t] [--output|-o]""".stripMargin
+       |  $printedName [-b,--bagId|-l,--list] [-t,--transform] [-o,--output]""".stripMargin
 
   version(s"$printedName v${ configuration.version }")
   banner(
@@ -45,18 +45,18 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
   private implicit val uuidParser: ValueConverter[UUID] = singleArgConverter(UUID.fromString)
 
-  val datasetId: ScallopOption[DatasetId] = opt("datasetId", short = 'd',
-    descr = "The datasetId (UUID) for which to transform the metadata")
+  val datasetId: ScallopOption[DatasetId] = opt("bagId", short = 'b',
+    descr = "The bag for which to transform the metadata")
   private val listPath: ScallopOption[Path] = opt("list", short = 'l',
-    descr = "A file containing a newline separated list of datasetIds (UUID) for which to transform the metadata")
+    descr = "A file containing a newline separated list of bag-ids for which to transform the metadata")
   val list: ScallopOption[File] = listPath.map(File(_))
   private val transformPath: ScallopOption[Path] = opt("transform", short = 't',
-    descr = "The file containing an XSLT to be applied to the metadata of the given dataset(s); " +
+    descr = "The file containing an XSLT to be applied to the metadata of the given bags(s); " +
       "if not provided, no transformation will be performed, but the input for the transformation will be returned.")
   val transform: ScallopOption[File] = transformPath.map(File(_))
   private val outputPath: ScallopOption[Path] = opt("output", short = 'o',
-    descr = "The directory in which to output the resultant metadata. " +
-      "If '-d' is used, this is optional (default to stdout); if '-l' is used, this argument is mandatory.")
+    descr = "The directory in which to output the resulting metadata. " +
+      "If '-b' is used, this is optional (default to stdout); if '-l' is used, this argument is mandatory.")
   val output: ScallopOption[File] = outputPath.map(File(_))
 
   requireOne(datasetId, listPath)


### PR DESCRIPTION
NO JIRA.

- [x] Solve build errors.

#### When applied it will
* Correct terminology usage. `datasetId` means Fedora-id, e.g., easy-dataset:123, `bagId` means the UUID of a single bag.
* Correct some old boilerplate docs about the installation.
* Updated the style of the command line synopsis.

#### Where should the reviewer @DANS-KNAW/easy start?
The readme, the only file that was updated.
