### PR TITLE
EASY-2382: Fetch metadata from bagstore in easy-transform-metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_2.12</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Scala utils -->
         <dependency>
@@ -76,6 +82,10 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalaj</groupId>
+            <artifactId>scalaj-http_2.12</artifactId>
         </dependency>
 
         <!-- Apache Commons -->

--- a/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
@@ -24,8 +24,6 @@ import javax.xml.transform.{ Transformer, TransformerFactory }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import resource.{ ManagedResource, managed }
 
-import scala.language.reflectiveCalls
-
 object Command extends App with DebugEnhancedLogging {
   val configuration = Configuration(File(System.getProperty("app.home")))
   val commandLine: CommandLineOptions = new CommandLineOptions(args, configuration) {
@@ -55,6 +53,6 @@ object Command extends App with DebugEnhancedLogging {
 
   for (datasetId <- singleDatasetId.map(Iterator(_)) getOrElse multipleDatasetIds;
        output <- fileOutput(datasetId) getOrElse consoleOutput) {
-    app.processDataset(datasetId, transformer, output)
+    app.processDataset(configuration, datasetId, transformer, output)
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
@@ -54,12 +54,12 @@ object Command extends App with DebugEnhancedLogging {
     .flatMap(ps => managed(new OutputStreamWriter(ps)))
 
   def process(bagId: BagId, output: Writer): Unit = {
-    app.processDataset(configuration, bagId, transformer, output)
+    app.processDataset(bagId, transformer, output)
     match {
       case Success(_) =>
       case Failure(e) =>
         logger.error(e.getMessage, e)
-        println(s"FAILED: ${ e.getMessage }")
+        Console.err.println(s"FAILED: ${ e.getMessage }")
     }
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/transform/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/CommandLineOptions.scala
@@ -45,7 +45,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
   private implicit val uuidParser: ValueConverter[UUID] = singleArgConverter(UUID.fromString)
 
-  val datasetId: ScallopOption[DatasetId] = opt("bagId", short = 'b',
+  val bagId: ScallopOption[BagId] = opt("bagId", short = 'b',
     descr = "The bag for which to transform the metadata")
   private val listPath: ScallopOption[Path] = opt("list", short = 'l',
     descr = "A file containing a newline separated list of bag-ids for which to transform the metadata")
@@ -59,7 +59,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
       "If '-b' is used, this is optional (default to stdout); if '-l' is used, this argument is mandatory.")
   val output: ScallopOption[File] = outputPath.map(File(_))
 
-  requireOne(datasetId, listPath)
+  requireOne(bagId, listPath)
   dependsOnAll(listPath, List(outputPath))
 
   validatePathExists(listPath)

--- a/src/main/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataApp.scala
@@ -19,23 +19,23 @@ import java.io.{ StringReader, StringWriter, Writer }
 
 import javax.xml.transform.stream.{ StreamResult, StreamSource }
 import javax.xml.transform.{ Source, Transformer }
+import nl.knaw.dans.easy.transform.bagstore.BagStore
 
 import scala.util.Try
 import scala.xml.{ Node, PrettyPrinter, XML }
 
-class EasyTransformMetadataApp(configuration: Configuration) {
+class EasyTransformMetadataApp(configuration: Configuration) extends BagStore(configuration) {
 
   private lazy val prettyPrinter = new PrettyPrinter(160, 2)
 
   // TODO implement
-  //  (1) fetch dataset.xml and files.xml from easy-bag-store
   //  (2) enrich files.xml
   //      (a) add <accessibleToRights> and <visibleToRights> if they're not provided; take dataset.xml - ddm:accessRight into account
   //      (b) replace the value in 'filepath' with the download url
   //  (3) combine dataset.xml and files.xml into a single METS xml
   //  (4) if provided, run the transformer to convert the METS xml to the output format and write it to 'output'
 
-  def processDataset(datasetId: DatasetId, transformer: Option[Transformer], output: Writer): Try[Unit] = {
+  def processDataset(configuration: Configuration, datasetId: DatasetId, transformer: Option[Transformer], output: Writer): Try[Unit] = {
     for {
       datasetXml <- fetchDatasetXml(datasetId)
       filesXml <- fetchFilesXml(datasetId)
@@ -46,9 +46,13 @@ class EasyTransformMetadataApp(configuration: Configuration) {
     } yield ()
   }
 
-  private def fetchDatasetXml(datasetId: DatasetId): Try[Node] = ???
+  def fetchDatasetXml(datasetId: DatasetId): Try[Node] = {
+    loadDatasetXml(datasetId)
+  }
 
-  private def fetchFilesXml(datasetId: DatasetId): Try[Node] = ???
+  def fetchFilesXml(datasetId: DatasetId): Try[Node] = {
+    loadFilesXml(datasetId)
+  }
 
   private def enrichFilesXml(xml: Node): Try[Node] = ???
 

--- a/src/main/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataApp.scala
@@ -35,10 +35,10 @@ class EasyTransformMetadataApp(configuration: Configuration) extends BagStore(co
   //  (3) combine dataset.xml and files.xml into a single METS xml
   //  (4) if provided, run the transformer to convert the METS xml to the output format and write it to 'output'
 
-  def processDataset(configuration: Configuration, datasetId: DatasetId, transformer: Option[Transformer], output: Writer): Try[Unit] = {
+  def processDataset(configuration: Configuration, bagId: BagId, transformer: Option[Transformer], output: Writer): Try[Unit] = {
     for {
-      datasetXml <- fetchDatasetXml(datasetId)
-      filesXml <- fetchFilesXml(datasetId)
+      datasetXml <- fetchDatasetXml(bagId)
+      filesXml <- fetchFilesXml(bagId)
       upgradedFilesXml <- enrichFilesXml(filesXml)
       metsXml <- makeMetsXml(datasetXml, upgradedFilesXml)
       resultXml <- transformer.fold(Try { metsXml })(transform(metsXml))
@@ -46,12 +46,12 @@ class EasyTransformMetadataApp(configuration: Configuration) extends BagStore(co
     } yield ()
   }
 
-  def fetchDatasetXml(datasetId: DatasetId): Try[Node] = {
-    loadDatasetXml(datasetId)
+  def fetchDatasetXml(bagId: BagId): Try[Node] = {
+    loadDatasetXml(bagId)
   }
 
-  def fetchFilesXml(datasetId: DatasetId): Try[Node] = {
-    loadFilesXml(datasetId)
+  def fetchFilesXml(bagId: BagId): Try[Node] = {
+    loadFilesXml(bagId)
   }
 
   private def enrichFilesXml(xml: Node): Try[Node] = ???

--- a/src/main/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataApp.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataApp.scala
@@ -24,9 +24,10 @@ import nl.knaw.dans.easy.transform.bagstore.BagStore
 import scala.util.Try
 import scala.xml.{ Node, PrettyPrinter, XML }
 
-class EasyTransformMetadataApp(configuration: Configuration) extends BagStore(configuration) {
+class EasyTransformMetadataApp(configuration: Configuration) {
 
   private lazy val prettyPrinter = new PrettyPrinter(160, 2)
+  private val bagStore = new BagStore(configuration)
 
   // TODO implement
   //  (2) enrich files.xml
@@ -35,7 +36,7 @@ class EasyTransformMetadataApp(configuration: Configuration) extends BagStore(co
   //  (3) combine dataset.xml and files.xml into a single METS xml
   //  (4) if provided, run the transformer to convert the METS xml to the output format and write it to 'output'
 
-  def processDataset(configuration: Configuration, bagId: BagId, transformer: Option[Transformer], output: Writer): Try[Unit] = {
+  def processDataset(bagId: BagId, transformer: Option[Transformer], output: Writer): Try[Unit] = {
     for {
       datasetXml <- fetchDatasetXml(bagId)
       filesXml <- fetchFilesXml(bagId)
@@ -47,11 +48,11 @@ class EasyTransformMetadataApp(configuration: Configuration) extends BagStore(co
   }
 
   def fetchDatasetXml(bagId: BagId): Try[Node] = {
-    loadDatasetXml(bagId)
+    bagStore.loadDatasetXml(bagId)
   }
 
   def fetchFilesXml(bagId: BagId): Try[Node] = {
-    loadFilesXml(bagId)
+    bagStore.loadFilesXml(bagId)
   }
 
   private def enrichFilesXml(xml: Node): Try[Node] = ???

--- a/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.transform.bagstore
+
+import java.net.{ URI, URL }
+
+import nl.knaw.dans.easy.transform.{ Configuration, DatasetId, HttpStatusException }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import scalaj.http.BaseHttp
+
+import scala.language.postfixOps
+import scala.util.{ Failure, Success, Try }
+import scala.xml.{ Elem, XML }
+
+abstract class BagStore(configuration: Configuration) extends DebugEnhancedLogging {
+
+  val baseUrl: URI = configuration.bagStoreConfig.baseURL
+  object Http extends BaseHttp(userAgent = s"easy-transform-metadata/${ configuration.version }")
+
+  def loadDatasetXml(bagId: DatasetId): Try[Elem] = {
+    loadXml(new URL(baseUrl.toString + s"bags/$bagId/metadata/dataset.xml"))
+  }
+
+  def loadFilesXml(bagId: DatasetId): Try[Elem] = {
+    loadXml(new URL(baseUrl.toString + s"bags/$bagId/metadata/files.xml"))
+  }
+
+  private def loadXml(url: URL): Try[Elem] = {
+    for {
+      response <- Try { Http(url.toString).method("GET").asString }
+      _ <- if (response.isSuccess) Success(())
+           else Failure(HttpStatusException(url.toString, response))
+    } yield XML.loadString(response.body)
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.transform.bagstore
 
 import java.net.{ URI, URL }
 
-import nl.knaw.dans.easy.transform.{ Configuration, DatasetId, HttpStatusException }
+import nl.knaw.dans.easy.transform.{ Configuration, BagId, HttpStatusException }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import scalaj.http.BaseHttp
 
@@ -30,11 +30,11 @@ abstract class BagStore(configuration: Configuration) extends DebugEnhancedLoggi
   val baseUrl: URI = configuration.bagStoreConfig.baseURL
   object Http extends BaseHttp(userAgent = s"easy-transform-metadata/${ configuration.version }")
 
-  def loadDatasetXml(bagId: DatasetId): Try[Elem] = {
+  def loadDatasetXml(bagId: BagId): Try[Elem] = {
     loadXml(new URL(baseUrl.toString + s"bags/$bagId/metadata/dataset.xml"))
   }
 
-  def loadFilesXml(bagId: DatasetId): Try[Elem] = {
+  def loadFilesXml(bagId: BagId): Try[Elem] = {
     loadXml(new URL(baseUrl.toString + s"bags/$bagId/metadata/files.xml"))
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
@@ -31,18 +31,18 @@ abstract class BagStore(configuration: Configuration) extends DebugEnhancedLoggi
   object Http extends BaseHttp(userAgent = s"easy-transform-metadata/${ configuration.version }")
 
   def loadDatasetXml(bagId: BagId): Try[Elem] = {
-    loadXml(new URL(baseUrl.toString + s"bags/$bagId/metadata/dataset.xml"))
+    loadXml(baseUrl.resolve(s"bags/$bagId/metadata/dataset.xml"))
   }
 
   def loadFilesXml(bagId: BagId): Try[Elem] = {
-    loadXml(new URL(baseUrl.toString + s"bags/$bagId/metadata/files.xml"))
+    loadXml(baseUrl.resolve(s"bags/$bagId/metadata/files.xml"))
   }
 
-  private def loadXml(url: URL): Try[Elem] = {
+  private def loadXml(uri: URI): Try[Elem] = {
     for {
-      response <- Try { Http(url.toString).method("GET").asString }
+      response <- Try { Http(uri.toString).method("GET").asString }
       _ <- if (response.isSuccess) Success(())
-           else Failure(HttpStatusException(url.toString, response))
+           else Failure(HttpStatusException(uri.toString, response))
     } yield XML.loadString(response.body)
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
@@ -28,6 +28,8 @@ import scala.xml.{ Elem, XML }
 class BagStore(configuration: Configuration) extends DebugEnhancedLogging {
 
   val baseUrl: URI = configuration.bagStoreConfig.baseURL
+  val connectTimeout: Int = configuration.bagStoreConfig.connectTimeout.toInt
+  val readTimeout: Int = configuration.bagStoreConfig.readTimeout.toInt
   object Http extends BaseHttp(userAgent = s"easy-transform-metadata/${ configuration.version }")
 
   def loadDatasetXml(bagId: BagId): Try[Elem] = {
@@ -40,7 +42,7 @@ class BagStore(configuration: Configuration) extends DebugEnhancedLogging {
 
   private def loadXml(uri: URI): Try[Elem] = {
     for {
-      response <- Try { Http(uri.toString).method("GET").asString }
+      response <- Try { Http(uri.toString).method("GET").timeout(connectTimeout, readTimeout).asString }
       _ <- if (response.isSuccess) Success(())
            else Failure(HttpStatusException(uri.toString, response))
     } yield XML.loadString(response.body)

--- a/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/bagstore/BagStore.scala
@@ -25,7 +25,7 @@ import scala.language.postfixOps
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, XML }
 
-abstract class BagStore(configuration: Configuration) extends DebugEnhancedLogging {
+class BagStore(configuration: Configuration) extends DebugEnhancedLogging {
 
   val baseUrl: URI = configuration.bagStoreConfig.baseURL
   object Http extends BaseHttp(userAgent = s"easy-transform-metadata/${ configuration.version }")

--- a/src/main/scala/nl/knaw/dans/easy/transform/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/package.scala
@@ -21,8 +21,8 @@ import scalaj.http.HttpResponse
 
 package object transform {
 
-  type DatasetId = UUID
-  type Identifiers = List[DatasetId]
+  type BagId = UUID
+  type Identifiers = List[BagId]
 
   case class HttpStatusException(msg: String, response: HttpResponse[String]) extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")
 }

--- a/src/main/scala/nl/knaw/dans/easy/transform/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/package.scala
@@ -22,7 +22,6 @@ import scalaj.http.HttpResponse
 package object transform {
 
   type BagId = UUID
-  type Identifiers = List[BagId]
 
   case class HttpStatusException(msg: String, response: HttpResponse[String]) extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")
 }

--- a/src/main/scala/nl/knaw/dans/easy/transform/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/package.scala
@@ -17,7 +17,12 @@ package nl.knaw.dans.easy
 
 import java.util.UUID
 
+import scalaj.http.HttpResponse
+
 package object transform {
 
   type DatasetId = UUID
+  type Identifiers = List[DatasetId]
+
+  case class HttpStatusException(msg: String, response: HttpResponse[String]) extends Exception(s"$msg - ${ response.statusLine }, details: ${ response.body }")
 }

--- a/src/test/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataAppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataAppSpec.scala
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.transform
+
+import java.net.URI
+import java.util.UUID
+
+import nl.knaw.dans.easy.transform.bagstore.BagStoreConfig
+import nl.knaw.dans.easy.transform.fixture.TestSupportFixture
+import okhttp3.HttpUrl
+import okhttp3.mockwebserver.{ MockResponse, MockWebServer }
+
+class EasyTransformMetadataAppSpec extends TestSupportFixture {
+
+  // configure the mock server
+  private val server = new MockWebServer
+  server.start()
+  private val test_server = "/test_server/"
+  private val baseUrl: HttpUrl = server.url(test_server)
+
+  private val app = new EasyTransformMetadataApp(Configuration("1.0.0", BagStoreConfig(baseUrl.uri(), 0l, 0l), new URI("")))
+  private val bagId: DatasetId = UUID.fromString("0000000-0000-0000-0000-000000000001")
+
+  "loadDatasetXml" should "return a correct xml-file" in {
+    server.enqueue(new MockResponse().setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><ddm:DDM>-</ddm:DDM>"))
+    val datasetXml = app.loadDatasetXml(bagId)
+    server.takeRequest.toString shouldBe s"GET ${ test_server }bags/$bagId/metadata/dataset.xml HTTP/1.1"
+    datasetXml.getOrElse("") shouldBe <ddm:DDM>-</ddm:DDM>
+  }
+
+  "loadFilesXml" should "return a correct xml-file" in {
+    server.enqueue(new MockResponse().setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><files>-</files>"))
+    val filesXml = app.loadFilesXml(bagId)
+    server.takeRequest.toString shouldBe s"GET ${ test_server }bags/$bagId/metadata/files.xml HTTP/1.1"
+    filesXml.getOrElse("") shouldBe <files>-</files>
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataAppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataAppSpec.scala
@@ -34,17 +34,15 @@ class EasyTransformMetadataAppSpec extends TestSupportFixture {
   private val app = new EasyTransformMetadataApp(Configuration("1.0.0", BagStoreConfig(baseUrl.uri(), 0l, 0l), new URI("")))
   private val bagId: DatasetId = UUID.fromString("0000000-0000-0000-0000-000000000001")
 
-  "loadDatasetXml" should "return a correct xml-file" in {
+  "loadDatasetXml" should "fetch the xml-file from a correct location" in {
     server.enqueue(new MockResponse().setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><ddm:DDM>-</ddm:DDM>"))
     val datasetXml = app.loadDatasetXml(bagId)
-    server.takeRequest.toString shouldBe s"GET ${ test_server }bags/$bagId/metadata/dataset.xml HTTP/1.1"
-    datasetXml.getOrElse("") shouldBe <ddm:DDM>-</ddm:DDM>
+    server.takeRequest.getRequestLine shouldBe s"GET ${ test_server }bags/$bagId/metadata/dataset.xml HTTP/1.1"
   }
 
-  "loadFilesXml" should "return a correct xml-file" in {
+  "loadFilesXml" should "fetch the xml-file from a correct location" in {
     server.enqueue(new MockResponse().setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><files>-</files>"))
     val filesXml = app.loadFilesXml(bagId)
-    server.takeRequest.toString shouldBe s"GET ${ test_server }bags/$bagId/metadata/files.xml HTTP/1.1"
-    filesXml.getOrElse("") shouldBe <files>-</files>
+    server.takeRequest.getRequestLine shouldBe s"GET ${ test_server }bags/$bagId/metadata/files.xml HTTP/1.1"
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataAppSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/EasyTransformMetadataAppSpec.scala
@@ -32,7 +32,7 @@ class EasyTransformMetadataAppSpec extends TestSupportFixture {
   private val baseUrl: HttpUrl = server.url(test_server)
 
   private val app = new EasyTransformMetadataApp(Configuration("1.0.0", BagStoreConfig(baseUrl.uri(), 0l, 0l), new URI("")))
-  private val bagId: DatasetId = UUID.fromString("0000000-0000-0000-0000-000000000001")
+  private val bagId: BagId = UUID.fromString("0000000-0000-0000-0000-000000000001")
 
   "loadDatasetXml" should "fetch the xml-file from a correct location" in {
     server.enqueue(new MockResponse().setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><ddm:DDM>-</ddm:DDM>"))

--- a/src/test/scala/nl/knaw/dans/easy/transform/fixture/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/fixture/TestSupportFixture.scala
@@ -20,5 +20,4 @@ import org.scalatest._
 trait TestSupportFixture extends FlatSpec
   with Matchers
   with Inside
-  with OptionValues {
-}
+  with OptionValues

--- a/src/test/scala/nl/knaw/dans/easy/transform/fixture/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/fixture/TestSupportFixture.scala
@@ -20,4 +20,5 @@ import org.scalatest._
 trait TestSupportFixture extends FlatSpec
   with Matchers
   with Inside
-  with OptionValues
+  with OptionValues {
+}


### PR DESCRIPTION
Fixes EASY-2382

#### When applied it will
* fetch metadata (`dataset.xml` and `files.xml`) from the bagstore

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)
