### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
@@ -16,12 +16,12 @@
 package nl.knaw.dans.easy.transform
 
 import java.io.{ OutputStreamWriter, Writer }
-import java.util.UUID
 
 import better.files.File
 import javax.xml.transform.stream.StreamSource
 import javax.xml.transform.{ Transformer, TransformerFactory }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import resource.{ ManagedResource, managed }
 
 import scala.util.{ Failure, Success }
@@ -35,7 +35,11 @@ object Command extends App with DebugEnhancedLogging {
 
   lazy val singleBagId: Option[BagId] = commandLine.bagId.toOption
   lazy val multipleBagIds: Iterator[BagId] = commandLine.list()
-    .lineIterator.map(UUID.fromString)
+    .lineIterator
+    .map(_.toUUID.toTry match {
+      case Success(uuid) => uuid
+      case Failure(e) => throw e
+    })
 
   lazy val transformer: Option[Transformer] = commandLine.transform.toOption
     .map(xsltFile => {

--- a/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
@@ -36,7 +36,8 @@ object Command extends App with DebugEnhancedLogging {
   lazy val singleBagId: Option[BagId] = commandLine.bagId.toOption
   lazy val multipleBagIds: Iterator[BagId] = commandLine.list()
     .lineIterator
-    .map(_.toUUID.toTry match {
+    .map(_.toUUID
+       .toTry match {
       case Success(uuid) => uuid
       case Failure(e) => throw e
     })

--- a/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/Command.scala
@@ -20,6 +20,7 @@ import java.io.{ OutputStreamWriter, Writer }
 import better.files.File
 import javax.xml.transform.stream.StreamSource
 import javax.xml.transform.{ Transformer, TransformerFactory }
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
 import resource.{ ManagedResource, managed }
@@ -36,11 +37,7 @@ object Command extends App with DebugEnhancedLogging {
   lazy val singleBagId: Option[BagId] = commandLine.bagId.toOption
   lazy val multipleBagIds: Iterator[BagId] = commandLine.list()
     .lineIterator
-    .map(_.toUUID
-       .toTry match {
-      case Success(uuid) => uuid
-      case Failure(e) => throw e
-    })
+    .map(_.toUUID.toTry.getOrRecover(e => throw e))
 
   lazy val transformer: Option[Transformer] = commandLine.transform.toOption
     .map(xsltFile => {

--- a/src/main/scala/nl/knaw/dans/easy/transform/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/CommandLineOptions.scala
@@ -16,10 +16,10 @@
 package nl.knaw.dans.easy.transform
 
 import java.nio.file.Path
-import java.util.UUID
 
 import better.files.File
-import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter, singleArgConverter }
+import nl.knaw.dans.lib.string._
+import org.rogach.scallop.{ ScallopConf, ScallopOption, stringConverter }
 
 class CommandLineOptions(args: Array[String], configuration: Configuration) extends ScallopConf(args) {
   appendDefaultToDescription = true
@@ -43,7 +43,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |Options:
        |""".stripMargin)
 
-  private implicit val uuidParser: ValueConverter[UUID] = singleArgConverter(UUID.fromString)
+  private implicit val uuidConverter = stringConverter.flatMap(_.toUUID.fold(e => Left(e.getMessage), uuid => Right(Option(uuid))))
 
   val bagId: ScallopOption[BagId] = opt("bagId", short = 'b',
     descr = "The bag for which to transform the metadata")

--- a/src/test/scala/nl/knaw/dans/easy/transform/XmlDdmToCarareSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/XmlDdmToCarareSpec.scala
@@ -33,7 +33,7 @@ class XmlDdmToCarareSpec extends TestSupportFixture with BeforeAndAfterEach {
 
   private val dataset = metadataDir / "metadata_PAN/dataset.xml"
   private val file = metadataDir / "metadata_PAN/files.xml"
-  private val bagId = UUID.fromString("12345678-1234-1234-1234-1234567890123")
+  private val bagId = UUID.fromString("12345678-1234-1234-1234-123456789012")
   private val downloadUrl = new URI("https://download/location/")
   private val ddmToCarareXSL = "src/main/resources/pan_ddm_carare.xsl"
   private val carareXSD = "src/main/resources/carare-v2.0.6.xsd"

--- a/src/test/scala/nl/knaw/dans/easy/transform/XmlTransformationSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/XmlTransformationSpec.scala
@@ -35,7 +35,7 @@ class XmlTransformationSpec extends TestSupportFixture with BeforeAndAfterEach {
   private val dataset_request = (metadataDir / "metadata_REQUEST_PERMISSION/dataset.xml").toJava
   private val dataset_no = (metadataDir / "metadata_NO_ACCESS/dataset.xml").toJava
   private val downloadUrl = new URI("https://download/location/")
-  private val bagId = UUID.fromString("12345678-1234-1234-1234-1234567890123")
+  private val bagId = UUID.fromString("12345678-1234-1234-1234-123456789012")
 
   override def beforeEach(): Unit = {
     super.beforeEach()


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method
 

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

