### PR TITLE
EASY-2771: DC schema requires explicit agent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,6 @@ Fixes EASY-
 * 
 
 #### By submitting this pull request I confirm that
-* [ ] all files contain licenses (`mvn license:format`)
-* [ ] the project compiles (`mvn clean install`)
-* [ ] all unit tests pass (`mvn test`)
 * [ ] the changes have been tested on `deasy`
 
 #### Where should the reviewer @DANS-KNAW/easy start?

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -9,3 +9,8 @@ bagstore.timeout_ms.connect=5000
 bagstore.timeout_ms.read=5000
 
 download.baseurl=http://deasy.dans.knaw.nl:20160/ark:/73189/
+
+#
+# User-Agent header used for http requests (such as retrieval of XSD schemas).
+# when omitted the default value will be easy-validate-dans-bag/<version>
+# http.agent=easy-validate-dans-bag

--- a/src/test/scala/nl/knaw/dans/easy/transform/fixture/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/fixture/TestSupportFixture.scala
@@ -27,6 +27,9 @@ trait TestSupportFixture extends AnyFlatSpec
   with Inside
   with OptionValues {
 
+  // Some (XSD) servers will deny requests if the User-Agent is set to the default value for Java
+  System.setProperty("http.agent", "Test")
+
   // disable logs from okhttp3.mockwebserver
   SLF4JBridgeHandler.removeHandlersForRootLogger()
   SLF4JBridgeHandler.install()


### PR DESCRIPTION
Fixes EASY-2771: DC schema requires explicit agent

#### When applied it will
* make DC schemas accessible again for validation
* 
* 

#### By submitting this pull request I confirm that
* [ ] the changes have been tested on `deasy`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* a maven build will fail on tests with the previous revision but will now succeed 
* [ ] run with previous version is expected to fail
* build deploy
* [ ] run should succeed

#### Related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)
