### PR TITLE
EASY-2782: Haal namespace dynamisch op in easy-transform-metadata

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/transform/XmlTransformation.scala
+++ b/src/main/scala/nl/knaw/dans/easy/transform/XmlTransformation.scala
@@ -26,9 +26,6 @@ import scala.xml.{ Elem, Node, XML }
 
 object XmlTransformation {
 
-  val DEFAULT_DC_PREFIX = "dcterms"
-  val DEFAULT_DC_URI = "http://purl.org/dc/terms/"
-
   private val accessibleToRightsMap = Map(
     AccessRights.OPEN_ACCESS -> AccessibleToRights.ANONYMOUS,
     AccessRights.OPEN_ACCESS_FOR_REGISTERED_USERS -> AccessibleToRights.KNOWN,
@@ -36,11 +33,11 @@ object XmlTransformation {
     AccessRights.NO_ACCESS -> AccessibleToRights.NONE)
 
   def enrichFilesXml(bagId: BagId, filesXml: Node, datasetXml: Node, downloadUrl: URI): Node = {
-    val dcNameSpace = getDcNamespace(filesXml)
+    val dctermsNameSpace = getDctermsNamespace(filesXml)
     val accessRights = getAccessRights(datasetXml)
     val rule = new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
-        case elem: Elem if elem.label == "file" => enrichFileElement(bagId, elem, dcNameSpace, accessRights, downloadUrl)
+        case elem: Elem if elem.label == "file" => enrichFileElement(bagId, elem, dctermsNameSpace, accessRights, downloadUrl)
         case _ => n
       }
     }
@@ -76,8 +73,8 @@ object XmlTransformation {
     file.copy(child = file.child ++ sourceElement)
   }
 
-  private def getDcNamespace(filesXml: Node): String = {
-    Option(filesXml.scope.getPrefix(DEFAULT_DC_URI)).getOrElse(DEFAULT_DC_PREFIX)
+  private def getDctermsNamespace(filesXml: Node): String = {
+    Option(filesXml.scope.getPrefix("http://purl.org/dc/terms/")).getOrElse("dcterms")
   }
 
   private def getAccessRights(datasetXml: Node): AccessRights = {

--- a/src/test/resources/metadata/metadata_OTHER_NAMESPACE/dataset.xml
+++ b/src/test/resources/metadata/metadata_OTHER_NAMESPACE/dataset.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ddm:DDM xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd"
+         xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+         xmlns:abr="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
+         xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+         xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+         xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+         xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
+         xmlns:dcmitype="http://purl.org/dc/dcmitype/"
+         xmlns:dcterms="http://purl.org/dc/terms/"
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/">
+    <ddm:profile>
+        <dc:title xml:lang="en">Dataset with files but no additional license</dc:title>
+        <dc:title xml:lang="nl">Jooo</dc:title>
+        <dc:title>Jaaha</dc:title>
+        <dc:description>A dataset with some files but no additional license</dc:description>
+        <dc:creator>A Creator</dc:creator>
+        <dc:creator>Joku muu</dc:creator>
+        <ddm:created>2015</ddm:created>
+        <ddm:available>2016</ddm:available>
+        <ddm:audience>D10000</ddm:audience>
+        <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    </ddm:profile>
+    <ddm:dcmiMetadata>
+        <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/licenses/by-nc-sa/4.0/</dcterms:license>
+        <dcterms:rightsHolder>me, just me</dcterms:rightsHolder>
+        <dcx-gml:spatial>
+            <Polygon xmlns="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                <description>A triangle between DANS, NWO and the railway station</description>
+                <exterior>
+                    <LinearRing>
+                        <description>main triangle</description>
+                        <posList>52.08110 4.34521 52.08071 4.34422 52.07913 4.34332 52.08110 4.34521</posList>
+                    </LinearRing>
+                </exterior>
+                <interior>
+                    <LinearRing>
+                        <description>hole1</description>
+                        <posList>52.080542 4.344215 52.080450 4.344323 52.080357 4.344110 52.080542 4.344215</posList>
+                    </LinearRing>
+                </interior>
+                <interior>
+                    <LinearRing>
+                        <description>hole2</description>
+                        <posList>52.080542 4.344215 52.080450 4.344323 52.080357 4.344110 52.080542 4.344215</posList>
+                    </LinearRing>
+                </interior>
+            </Polygon>
+        </dcx-gml:spatial>
+    </ddm:dcmiMetadata>
+</ddm:DDM>

--- a/src/test/resources/metadata/metadata_OTHER_NAMESPACE/files.xml
+++ b/src/test/resources/metadata/metadata_OTHER_NAMESPACE/files.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files xmlns:dc="http://purl.org/dc/terms/" xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/files/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd http://easy.dans.knaw.nl/schemas/bag/metadata/files/ http://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd">
+    <file filepath="data/path/to/file.txt">
+        <dc:format>text/plain</dc:format>
+        <accessibleToRights>NONE</accessibleToRights>
+        <visibleToRights>RESTRICTED_REQUEST</visibleToRights>
+    </file>
+    <file filepath="data/quicksort.hs">
+        <dc:format>text/plain</dc:format>
+    </file>
+</files>

--- a/src/test/scala/nl/knaw/dans/easy/transform/XmlTransformationSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/transform/XmlTransformationSpec.scala
@@ -30,10 +30,12 @@ class XmlTransformationSpec extends TestSupportFixture with BeforeAndAfterEach {
   private val files_open_registered = (metadataDir / "metadata_OPEN_ACCESS_FOR_REGISTERED_USERS/files.xml").toJava
   private val files_request = (metadataDir / "metadata_REQUEST_PERMISSION/files.xml").toJava
   private val files_no = (metadataDir / "metadata_NO_ACCESS/files.xml").toJava
+  private val files_other_namespace = (metadataDir / "metadata_OTHER_NAMESPACE/files.xml").toJava
   private val dataset_open = (metadataDir / "metadata_OPEN_ACCESS/dataset.xml").toJava
   private val dataset_open_registered = (metadataDir / "metadata_OPEN_ACCESS_FOR_REGISTERED_USERS/dataset.xml").toJava
   private val dataset_request = (metadataDir / "metadata_REQUEST_PERMISSION/dataset.xml").toJava
   private val dataset_no = (metadataDir / "metadata_NO_ACCESS/dataset.xml").toJava
+  private val dataset_other_namespace = (metadataDir / "metadata_OTHER_NAMESPACE/dataset.xml").toJava
   private val downloadUrl = new URI("https://download/location/")
   private val bagId = UUID.fromString("12345678-1234-1234-1234-123456789012")
 
@@ -59,6 +61,20 @@ class XmlTransformationSpec extends TestSupportFixture with BeforeAndAfterEach {
     val sourceElement = (XmlTransformation.enrichFilesXml(bagId, filesXml, datasetXml, downloadUrl) \ "file" \ "source").head
     sourceElement.child should have size 1
     firstFileElement.child should have size origSizeFirstFileElement + 1
+  }
+
+  it should "use dcterms namespace in the new <source> element" in {
+    val filesXml = XML.loadFile(files_open)
+    val datasetXml = XML.loadFile(dataset_open)
+    val sourceElement = (XmlTransformation.enrichFilesXml(bagId, filesXml, datasetXml, downloadUrl) \ "file" \ "source").head
+    sourceElement.toString should startWith ("<dcterms:source>")
+  }
+
+  it should "use dc namespace in the new <source> element" in {
+    val filesXml = XML.loadFile(files_other_namespace)
+    val datasetXml = XML.loadFile(dataset_other_namespace)
+    val sourceElement = (XmlTransformation.enrichFilesXml(bagId, filesXml, datasetXml, downloadUrl) \ "file" \ "source").head
+    sourceElement.toString should startWith ("<dc:source>")
   }
 
   it should "give download path as value for the new <source> element in all file elements" in {


### PR DESCRIPTION
Fixes EASY-2782

#### When applied it will
* fetch `dc` namespace for the new `source` element from `filesXml`
* if not found in filesXml the default namespace `dcterms` is used

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)
